### PR TITLE
Fix for properly build cake on win32 systems

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,7 +1,7 @@
 {exec} = require 'child_process'
 
 task 'build', 'compiles *.coffee to *.js', (options) ->
-  exec 'coffee -lcb examples/*.coffee lib/*.coffee', (err, stdout, stderr) ->
+  exec 'coffee -lbc examples && coffee -lbc lib' , (err, stdout, stderr) ->
     throw err if err
     console.log(stderr) if stderr
 

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   "dependencies": {
     "coffee-script": "~1.1.2"
   },
-  "devDependencies": {},
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,4 @@
     "coffee-script": "~1.1.2"
   },
   "devDependencies": {},
-  "scripts": {
-    "install": "cake clear; cake build",
-    "update": "cake clear; cake build"
-  }
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
   "dependencies": {
     "coffee-script": "~1.1.2"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "scripts": {
+    "install": "cake build && cake build",
+    "update": "cake build && cake build"
+  }
 }


### PR DESCRIPTION
I've found that cake didn't works properly on my Windows 7 because of use the ";"in install script parameter. Also execution of coffee compile command cause the error "... File not found *.coffee ..."
I tested my fix both *nix and win32 - works well for me.
